### PR TITLE
Add verification script and document test run

### DIFF
--- a/docs/test-report.md
+++ b/docs/test-report.md
@@ -1,0 +1,20 @@
+# Test Execution Report
+
+## Environment Preparation
+- Copied `.env_sample` to `.env` to supply the environment variables expected by Docker and the application runtime.
+- Attempted to run `docker compose build`, but the command is unavailable in the execution environment, so Docker-based verification could not be completed here.
+
+## Commands Executed
+| Step | Command | Result |
+| --- | --- | --- |
+| Lint | `npm run lint` | Passed |
+| Unit tests | `npm run test` | Passed |
+| E2E tests | `npm run test:e2e` | Passed after installing the optional `sqlite3` dependency required by the in-memory database used for tests |
+| Build | `npm run build` | Passed |
+| Format | `npm run format` | No changes required |
+
+All tests now pass locally, and a new aggregated script (`npm run verify`) is available to execute linting, unit tests, E2E tests, and the build in a single command.
+
+## Notes
+- Docker Compose is not available in this CI environment, so container-based checks should be performed manually in an environment where Docker is installed.
+- The SQLite driver (`sqlite3`) must remain installed to allow the TypeORM in-memory database used during testing to bootstrap correctly.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
-    "migration:run": "typeorm-ts-node-commonjs migration:run -d data-source.ts"
+    "migration:run": "typeorm-ts-node-commonjs migration:run -d data-source.ts",
+    "verify": "npm run lint && npm run test && npm run test:e2e && npm run build"
   },
   "dependencies": {
     "@nestjs/common": "^10.0.0",


### PR DESCRIPTION
## Summary
- add an npm `verify` script that chains linting, unit tests, e2e tests, and the build
- document the executed test suite and the Docker availability limitation in `docs/test-report.md`

## Testing
- npm run verify

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690feaddf90c83328bf419a44a15b7b8)